### PR TITLE
使用json.loads代替eval修正path解析问题

### DIFF
--- a/v2rayL-GUI/sub2conf_api.py
+++ b/v2rayL-GUI/sub2conf_api.py
@@ -7,7 +7,7 @@ import json
 import pickle
 import requests
 import urllib.parse as parse
-from config import conf_template as conf
+from config import conf_template as confclient
 
 
 class Sub2Conf(object):
@@ -41,7 +41,7 @@ class Sub2Conf(object):
 
     def b642conf(self, prot, tp, b64str):
         if prot == "vmess":
-            ret = eval(parse.unquote(base64.b64decode(b64str).decode()))
+            ret = json.loads(parse.unquote(base64.b64decode(b64str).decode()))
             region = ret['ps']
 
         elif prot == "shadowsocks":

--- a/v2rayL-GUI/sub2conf_api.py
+++ b/v2rayL-GUI/sub2conf_api.py
@@ -7,7 +7,7 @@ import json
 import pickle
 import requests
 import urllib.parse as parse
-from config import conf_template as confclient
+from config import conf_template as conf
 
 
 class Sub2Conf(object):


### PR DESCRIPTION
使用eval后得到的path是“\\/”，这样使用得到的V2Ray配置文件config.json将无法与代理服务器通信（返回404错误），比如这样包含这样配置的config.json是有问题的
```json
            "streamSettings": {
                "network": "ws",
                "security": "tls",
                "tlssettings": {
                    "allowInsecure": true,
                    "serverName": "tls"
                },
                "wssettings": {
                    "connectionReuse": true,
                    "headers": {
                        "Host": ""
                    },
                    "path": "\\/"
                }
            },
```