### PR TITLE
Missing tls in security for tcp and kcp.

### DIFF
--- a/v2rayL-GUI/sub2conf_api.py
+++ b/v2rayL-GUI/sub2conf_api.py
@@ -135,13 +135,13 @@ class Sub2Conf(object):
                         "uplinkCapacity": 12,
                         "writeBufferSize": 1
                     },
-                    "security": ""
+                    "security": "tls" if use_conf["tls"] else ""
                 }
             # tcp
             elif use_conf["net"] == "tcp":
                 conf['outbounds'][0]["streamSettings"] = {
                     "network": use_conf["net"],
-                    "security": "",
+                    "security": "tls" if use_conf["tls"] else "",
                     "tcpsettings": {
                         "connectionReuse": True,
                         "header": {


### PR DESCRIPTION
tcp 和 kcp 配置里缺少对tls的解析。