### PR TITLE
修复base64 padding导致订阅崩溃问题 fixed #15

### DIFF
--- a/sub2conf.py
+++ b/sub2conf.py
@@ -71,16 +71,16 @@ class Sub2Conf(object):
 
     def b642conf(self, prot, tp, b64str):
         if prot == "vmess":
-            ret = eval(base64.b64decode(b64str).decode())
+            ret = eval(base64.b64decode(b64str + "==").decode())
             region = ret['ps']
 
         elif prot == "ss":
             string = b64str.split("#")
             cf = string[0].split("@")
             if len(cf) == 1:
-                tmp = base64.b64decode(cf[0]).decode()  # aes-256-cfb:541603466@142.93.50.78:9898
+                tmp = base64.b64decode(cf[0] + "==").decode()  # aes-256-cfb:541603466@142.93.50.78:9898
             else:
-                tmp = base64.b64decode(cf[0]).decode()+"@"+cf[1]
+                tmp = base64.b64decode(cf[0] + "==").decode()+"@"+cf[1]
             ret = {
                 "method": tmp.split(":")[0],
                 "port": tmp.split(":")[2],

--- a/v2rayL-GUI/sub2conf_api.py
+++ b/v2rayL-GUI/sub2conf_api.py
@@ -50,16 +50,16 @@ class Sub2Conf(object):
         :return:
         """
         if prot == "vmess":
-            ret = json.loads(parse.unquote(base64.b64decode(b64str).decode()).replace("\'", "\""))
+            ret = json.loads(parse.unquote(base64.b64decode(b64str + "==").decode()).replace("\'", "\""))
             region = ret['ps']
 
         elif prot == "shadowsocks":
             string = b64str.split("#")
             cf = string[0].split("@")
             if len(cf) == 1:
-                tmp = parse.unquote(base64.b64decode(cf[0]).decode())
+                tmp = parse.unquote(base64.b64decode(cf[0] + "==").decode())
             else:
-                tmp = parse.unquote(base64.b64decode(cf[0]).decode() + "@" + cf[1])
+                tmp = parse.unquote(base64.b64decode(cf[0] + "==").decode() + "@" + cf[1])
                 print(tmp)
             ret = {
                 "method": tmp.split(":")[0],


### PR DESCRIPTION
所有base64 decode前添加两个等号，
因为python只报错缺等号的情况，不报错等号过多的情况，